### PR TITLE
Warn user when scb is provided but there is no file

### DIFF
--- a/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/Cqld4Space.java
+++ b/adapter-cqld4/src/main/java/io/nosqlbench/adapter/cqld4/Cqld4Space.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -97,7 +98,7 @@ public class Cqld4Space implements AutoCloseable {
 //        int port = cfg.getOptional(int.class, "port").orElse(9042);
 
         Optional<String> scb = cfg.getOptional(String.class, "secureconnectbundle", "scb");
-        
+
         if (scb.isPresent()) {
             Optional<InputStream> stream =
                 scb.flatMap(s -> NBIO.all().pathname(s).first().map(Content::getInputStream));


### PR DESCRIPTION
### Description

When a user provides the secureconnectbundle to a cqld4 adapter, it silently fails in the driver without telling the user it could not find the file

**Issues:** [1668](https://github.com/nosqlbench/nosqlbench/issues/1668) and [982](https://github.com/nosqlbench/nosqlbench/issues/982)

Original Error:
```
java.lang.RuntimeException: javax.script.ScriptException: io.nosqlbench.nb.api.errors.OpConfigError: Error while configuring op from workload template: 
[from:yaml:/path/to/workload.yaml]  cause: AllNodesFailedException:Could not reach any contact point, 
make sure you've provided valid addresses (showing first 1 nodes, use getAllErrors() for more): 
Node(endPoint=localhost/127.0.0.1:9042, hostId=null, hashCode=31dd7ba2): 
...
```

After adding warning:
```
4047 ERROR [main] Cqld4Space   Unable to load path /path/to/non-existing/bundle.zip
4059 ERROR [main] NBInvokableCommand error in command (stack trace follows): NBScriptedCommand 
{container="default",instance="default",jobname="nosqlbench",node="192.168.0.179",session="nOjgBos",step="phase_1"}: 
java.lang.RuntimeException: javax.script.ScriptException: io.nosqlbench.nb.api.errors.OpConfigError: Error while configuring 
op from workload template: [from:yaml:/path/to/workload.yaml]  cause: RuntimeException:Unable to load path 
/path/to/non-existing/bundle.zip Unable to load path /path/to/non-existing/bundle.zip
...
```