### PR TITLE
Throw an error when the same activity parameter is set more than once.

### DIFF
--- a/engine-core/src/main/java/io/nosqlbench/engine/api/scenarios/NBCLIScenarioPreprocessor.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/api/scenarios/NBCLIScenarioPreprocessor.java
@@ -170,7 +170,7 @@ public class NBCLIScenarioPreprocessor {
                 // here, we should actually parse the command using argv rules
 
                 cmd = userParamsInterp.apply(cmd);
-                LinkedHashMap<String, SCNamedParam> parsedStep = parseStep(cmd);
+                LinkedHashMap<String, SCNamedParam> parsedStep = parseStep(cmd, stepName, scenarioName);
                 LinkedHashMap<String, String> usersCopy = new LinkedHashMap<>(userProvidedParams);
                 LinkedHashMap<String, String> buildingCmd = new LinkedHashMap<>();
 
@@ -252,7 +252,7 @@ public class NBCLIScenarioPreprocessor {
 
     private static final Pattern WordAndMaybeAssignment = Pattern.compile("(?<name>\\w[-_\\d\\w.]+)((?<oper>=+)(?<val>.+))?");
 
-    private static LinkedHashMap<String, SCNamedParam> parseStep(String cmd) {
+    private static LinkedHashMap<String, SCNamedParam> parseStep(String cmd, String stepName, String scenarioName) {
         LinkedHashMap<String, SCNamedParam> parsedStep = new LinkedHashMap<>();
 
         String[] namedStepPieces = cmd.split(" +");
@@ -270,6 +270,10 @@ public class NBCLIScenarioPreprocessor {
             String commandName = matcher.group("name");
             String assignmentOp = matcher.group("oper");
             String assignedValue = matcher.group("val");
+            if (parsedStep.containsKey(commandName)) {
+                String errorMessage = String.format("Duplicate occurrence of parameter \"%s\" on step \"%s\" of scenario \"%s\", step command: \"%s\"", commandName, stepName, scenarioName, cmd);
+                throw new BasicError(errorMessage);
+            }
             parsedStep.put(commandName, new SCNamedParam(commandName, assignmentOp, assignedValue));
         }
         return parsedStep;

--- a/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/CmdParser.java
+++ b/engine-core/src/main/java/io/nosqlbench/engine/core/lifecycle/session/CmdParser.java
@@ -72,6 +72,9 @@ public class CmdParser {
                 Map<String,CmdArg> params = new LinkedHashMap<>();
                 while (cmdstructs.peekFirst() instanceof parameter param) {
                     cmdstructs.removeFirst();
+                    if (params.containsKey(param.name())) {
+                        throw new BasicError("Duplicate occurrence of option: " + param.name());
+                    }
                     params.put(param.name(),CmdArg.of(cmd.name(),param.name(),param.op(),param.value()));
                 }
                 cmds.add(new Cmd(cmd.name(),params));


### PR DESCRIPTION
### Description
- Throw an error when duplicate parameters are found in cli commands and scenario definitions
- Related ticket: [#1638](https://github.com/nosqlbench/nosqlbench/issues/1638)

### Output Sample
- Duplicate parameter on cli
```
$ java -jar nb5.jar run workload=iot.yaml cycles=10 tags=block:"main.*" driver=stdout threads=auto threads=10
    5813 ERROR [main] ERRORHANDLER Duplicate occurrence of option: threads
    5813 ERROR [main] ERRORHANDLER for the full stack trace, run with --show-stacktraces
Scenario stopped due to error. See logs for details.
```
- Duplicate parameter inside scenario
```
$ head -n 11 iot.yaml | tail -n 6
scenarios:
  basic_check:
    schema: run driver=stdout tags==block:schema threads==1 cycles==UNDEF threads=auto
    truncate: run driver=stdout tags==block:schema threads==1 cycles==UNDEF
    rampup: run driver=stdout tags==block:rampup cycles===TEMPLATE(rampup-cycles,10) threads=auto
    main: run driver=stdout tags==block:"main.*" cycles===TEMPLATE(main-cycles,10) threads=auto

$ java -jar nb5.jar iot.yaml basic_check
    6155 ERROR [main] ERRORHANDLER Duplicate occurrence of parameter "threads" on step "schema" of scenario "basic_check", step command: "run driver=stdout tags==block:schema threads==1 cycles==UNDEF threads=auto"
    6155 ERROR [main] ERRORHANDLER for the full stack trace, run with --show-stacktraces
Scenario stopped due to error. See logs for details.
```