### PR TITLE
Binding Parser grammar update

### DIFF
--- a/nb-virtdata/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/grammars/VirtData.g4
+++ b/nb-virtdata/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/grammars/VirtData.g4
@@ -3,7 +3,7 @@ grammar VirtData;
 
 virtdataRecipe : virtdataFlow (specend virtdataFlow?)* EOF ;
 
-virtdataFlow : (COMPOSE)? expression (';' expression?)* ;
+virtdataFlow : (COMPOSE)? expression (';' expression? | WS? expression)* ;
 
 expression : (lvalue ASSIGN)? virtdataCall ;
 

--- a/nb-virtdata/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/parser/VirtDataDSL.java
+++ b/nb-virtdata/virtdata-lang/src/main/java/io/nosqlbench/virtdata/lang/parser/VirtDataDSL.java
@@ -20,7 +20,12 @@ import io.nosqlbench.virtdata.lang.ast.VirtDataAST;
 import io.nosqlbench.virtdata.lang.ast.VirtDataFlow;
 import io.nosqlbench.virtdata.lang.generated.VirtDataLexer;
 import io.nosqlbench.virtdata.lang.generated.VirtDataParser;
-import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CodePointCharStream;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
### Description
- Issue: [#1134](https://github.com/nosqlbench/nosqlbench/issues/1134)
- Invalid construction of bindings is silently discarded, but an error should be thrown
- The case `Add(10) Add(20)` should be working (space should work in ileu of a semicolon)

### Comparison
- Space instead of semicolon: `Add(10) Add(20)`
    ```
    # before
    $ java -jar nb5.jar run workload=iot.yaml tags=block:main-read cycles=10 driver=stdout
    10
    11
    ...
    
    # new
    $ java -jar nb5.jar run workload=iot.yaml tags=block:main-read cycles=10 driver=stdout
    30
    31
    ...
    ```
- Invalid syntax: `Add(10); - Add(20)`
  ```
  # before
  $ java -jar nb5.jar run workload=iot.yaml tags=block:main-read cycles=10 driver=stdout
  line 1:9 token recognition error at: '- '
  30
  31
  ...
  
  # new
  $ java -jar nb5.jar run workload=iot.yaml tags=block:main-read cycles=10 driver=stdout
  line 1:9 token recognition error at: '- '
      6164 WARN  [main] VirtDataDSL  Error while parsing flow:LexerNoViableAltException('-')
      6165 ERROR [main] NBINVOKE     error   [CMD_run {container="default",instance="default",jobname="nosqlbench",node="192.168.1.34",session="nYmU6Fq",step="run"}]: (stack trace follows): CMD_run {container="default",instance="default",jobname="nosqlbench",node="192.168.1.34",session="nYmU6Fq",step="run"}: java.lang.RuntimeException: Error while parsing binding specification 'Add(10); - Add(20)': java.lang.RuntimeException: LexerNoViableAltException('-')
  java.lang.RuntimeException: Error while parsing binding specification 'Add(10); - Add(20)': java.lang.RuntimeException: LexerNoViableAltException('-')
	  at io.nosqlbench.virtdata.core.bindings.VirtData.getOptionalMapper(VirtData.java:102)
	  at io.nosqlbench.virtdata.core.templates.StringCompositor.lambda$new$1(StringCompositor.java:52)
	  at java.base/java.util.HashMap.forEach(HashMap.java:1429)
	  at io.nosqlbench.virtdata.core.templates.StringCompositor.<init>(StringCompositor.java:51)
	  at io.nosqlbench.virtdata.core.templates.StringCompositor.<init>(StringCompositor.java:75)
	  at io.nosqlbench.virtdata.core.templates.StringBindings.<init>(StringBindings.java:49)
	  at io.nosqlbench.virtdata.core.templates.StringBindings.<init>(StringBindings.java:45)
  ...
  ```