### PR TITLE
Better error when users select a scenario step without setting the scenario

### DIFF
--- a/nb-engine/nb-engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIScenarioPreprocessorTest.java
+++ b/nb-engine/nb-engine-cli/src/test/java/io/nosqlbench/engine/cli/NBCLIScenarioPreprocessorTest.java
@@ -201,4 +201,11 @@ public class NBCLIScenarioPreprocessorTest {
             .isThrownBy(() -> new NBCLIOptions(new String[]{"scenario_test", "duplicate_param"}, NBCLIOptions.Mode.ParseAllOptions))
             .withMessageContaining("Duplicate occurrence of parameter \"threads\"");
     }
+
+    @Test
+    public void testThatSuggestionsAreShownForDirectStepNameUsage() {
+        assertThatExceptionOfType(BasicError.class)
+            .isThrownBy(() -> new NBCLIOptions(new String[]{"scenario_test", "schema"}, NBCLIOptions.Mode.ParseAllOptions))
+            .withMessageContainingAll("default.schema", "schema_only.schema");
+    }
 }

--- a/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/scenarios/NBCLIScenarioPreprocessor.java
+++ b/nb-engine/nb-engine-core/src/main/java/io/nosqlbench/engine/api/scenarios/NBCLIScenarioPreprocessor.java
@@ -133,8 +133,20 @@ public class NBCLIScenarioPreprocessor {
             if (nameparts.length==1) {
                 Map<String, String> namedScenario = scenarios.getNamedScenario(scenarioName);
                 if (namedScenario==null) {
-                    throw new BasicError("Unable to find named scenario '" + scenarioName + "' in workload '" + workloadName
-                    + "', but you can pick from one of: " + String.join(", ", scenarios.getScenarioNames()));
+                    List<String> matchingSteps = new LinkedList<>();
+                    for (String scenario : scenarios.getScenarioNames()) {
+                        Map<String, String> selectedScenario = scenarios.getNamedScenario(scenario);
+                        if (selectedScenario.containsKey(scenarioName)) {
+                            matchingSteps.add(scenario + "." + scenarioName);
+                        }
+                    }
+                    if (matchingSteps.isEmpty()) {
+                        throw new BasicError("Unable to find named scenario '" + scenarioName + "' in workload '" + workloadName
+                            + "', but you can pick from one of: " + String.join(", ", scenarios.getScenarioNames()));
+                    } else {
+                        throw new BasicError("Unable to find named scenario '" + scenarioName + "' in workload '" + workloadName
+                            + "', you might be looking for one of these scenario steps: " + String.join(", ", matchingSteps));
+                    }
                 }
                 namedSteps.putAll(namedScenario);
             } else {


### PR DESCRIPTION
### Description
When the scenario step exists under at least one named scenario, and the users doesn't provide the scenario name, they should be told that they might be looking for ...

Issue: [#1944](https://github.com/nosqlbench/nosqlbench/issues/1944)

```
# before
$ java -jar nb5.jar iot2.yaml main
    6035 ERROR [main] ERRORHANDLER Unable to find named scenario 'main' in workload 'iot2.yaml', but you can pick from one of: default, astra, basic_check
    6035 ERROR [main] ERRORHANDLER for the full stack trace, run with --show-stacktraces
Scenario stopped due to error. See logs for details.

# after
$ java -jar nb5.jar iot2.yaml main
    6006 ERROR [main] ERRORHANDLER Unable to find named scenario 'main' in workload 'iot2.yaml', you might be looking for one of these scenario steps: default.main, astra.main, basic_check.main
    6007 ERROR [main] ERRORHANDLER for the full stack trace, run with --show-stacktraces
Scenario stopped due to error. See logs for details.
```